### PR TITLE
Better handling of LunchGroup Status and Date Determination

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -11,7 +11,7 @@ class ApplicationController < ActionController::Base
 
     (user_time, user_place) = parse_lunch_command_payload(params[:text])
 
-    parsed_time = Chronic.parse(user_time)
+    parsed_time = Chronic.parse("today " + user_time)
     if parsed_time.nil?
       render plain: "'#{params[:text]}' is an invalid time. Please specify a time to go to lunch."
       return

--- a/app/jobs/assemble_group.rb
+++ b/app/jobs/assemble_group.rb
@@ -2,8 +2,8 @@ class AssembleGroup < ApplicationJob
   def perform(channel_id, initiating_user_id, message_id)
     users_to_notify = get_users_who_reacted(channel_id, message_id)
     group_chat = create_group_chat(initiating_user_id, users_to_notify)
+    group = LunchGroup.where(channel_id: channel_id, message_id: message_id).first
     if group_chat
-      group = LunchGroup.where(channel_id: channel_id, message_id: message_id).first
       destination = group.destination
       notify_users(group_chat, destination)
       create_poll(group_chat) if destination.nil?

--- a/app/jobs/assemble_group.rb
+++ b/app/jobs/assemble_group.rb
@@ -8,6 +8,7 @@ class AssembleGroup < ApplicationJob
       notify_users(group_chat, destination)
       create_poll(group_chat) if destination.nil?
       group.update(status: 'assembled')
+      DepartGroup.set(wait_until: group.departure_time).perform_later(group.id)
     else
       group.destroy
     end

--- a/app/jobs/assemble_group.rb
+++ b/app/jobs/assemble_group.rb
@@ -1,12 +1,12 @@
 class AssembleGroup < ApplicationJob
   def perform(channel_id, initiating_user_id, message_id)
     users_to_notify = get_users_who_reacted(channel_id, message_id)
-    group_id = create_group(initiating_user_id, users_to_notify)
-    if group_id
+    group_chat = create_group_chat(initiating_user_id, users_to_notify)
+    if group_chat
       group = LunchGroup.where(channel_id: channel_id, message_id: message_id).first
       destination = group.destination
-      notify_users(group_id, destination)
-      create_poll(group_id) if destination.nil?
+      notify_users(group_chat, destination)
+      create_poll(group_chat) if destination.nil?
       group.update(status: 'assembled')
     else
       group.destroy
@@ -35,7 +35,7 @@ class AssembleGroup < ApplicationJob
     end
   end
 
-  def create_group(initiating_user_id, users)
+  def create_group_chat(initiating_user_id, users)
     all_users = (users << initiating_user_id)
       .uniq
       .join(',')
@@ -51,26 +51,26 @@ class AssembleGroup < ApplicationJob
     end
   end
 
-  def notify_users(group_id, destination)
+  def notify_users(group_chat, destination)
     destination ||= "lunch"
-    client.chat_postMessage(channel: group_id,
+    client.chat_postMessage(channel: group_chat,
                             text: "Hey, you're stuck having #{destination} together",
                             as_user: true)
   end
 
-  def create_poll(group_id)
+  def create_poll(group_chat)
     nums = ["one","two","three","four","five","six","seven","eight","nine","ten"]
     places_rand = Place.order("RANDOM()").limit(10).map(&:name)
     text = "Where do you want to go?\n"
     nums.zip(places_rand).each do |num, place|
         text += ":#{num}: #{place}\n"
     end
-    resp = client.chat_postMessage(channel: group_id,
+    resp = client.chat_postMessage(channel: group_chat,
                             text: text,
                             as_user: true)
     response_ts = resp.message.ts
     nums.each do |num|
-        client.reactions_add(name: num, channel: group_id, timestamp: response_ts)
+        client.reactions_add(name: num, channel: group_chat, timestamp: response_ts)
     end    
   end
 end

--- a/app/jobs/depart_group.rb
+++ b/app/jobs/depart_group.rb
@@ -1,0 +1,6 @@
+class DepartGroup < ApplicationJob
+  def perform(group_id)
+    group = LunchGroup.find(group_id)
+    group.update(status: 'departed')
+  end
+end


### PR DESCRIPTION
Bugfixes:
* `LunchGroup`s with no participants are now handled--the lunch group is deleted.
* `LunchGroup`s now end up `departed` at the appropriate time!
* Work around a `chronic` bug where times like `13:10` are interpreted as being tomorrow instead of today.

Closes #19.